### PR TITLE
0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 # FluFFyPipe
 NIPT analysis pipeline, using WisecondorX for detecting aneuplodies and large CNVs, AMYCNE for FFY and PREFACE for FF prediction (optional). FluFFYPipe produces a variety of output files, as well as a per batch csv summary.
 
-FluFFyPipe is still in early development, use at your own risk!
-
 <p align="center">
 <img src="https://github.com/J35P312/FluFFyPipe/blob/master/logo/IMG_20200320_132001.jpg" width="400" height="400" >
 </p>

--- a/example_config/Config.clean.json
+++ b/example_config/Config.clean.json
@@ -1,0 +1,45 @@
+{
+	"align":{
+		"tmpdir":"$TMPDIR/",
+		"ntasks":16,
+		"mem":0
+
+	},
+	"amycne":{
+		"minq":10
+
+	},
+	"wisecondorx":{
+		"reftest":"",
+		"testbinsize":500000,
+		"refpreface":"",
+		"prefacebinsize":100000,
+		"blacklist":"",
+		"zscore": 1.5
+	},
+	"tiddit":{
+		"binsize":50000
+	},
+	"preface":{
+		"model_dir":"",
+		"modelsettings":"--olm"
+
+	},
+	"picard":{
+		"javasettings":"-Xms4G -Xmx4G"
+	},
+	"reference":"",
+	"singularity":"",
+	"slurm": {
+		"account":"",
+		"time":"5:00:00",
+		"ntasks":1,
+		"mem":"8G"
+
+
+	},
+	"summary":{
+		"mincnv":10000000,
+		"zscore":5
+	}
+}

--- a/example_config/README.txt
+++ b/example_config/README.txt
@@ -2,7 +2,12 @@
 	#Alignment settings
 	"align":{
 		#Temporary files are written here
-		"tmpdir":"$TMPDIR/"
+		"tmpdir":"$TMPDIR/",
+                #number of cpu for alignment
+                "ntasks":16,
+		#amount of memory (set to 0 in order to use all memory available to the cores)
+                "mem":0
+
 	},
 
 	#AMYCNE FFY estimation settings

--- a/fluffy/commands/wisecondor.py
+++ b/fluffy/commands/wisecondor.py
@@ -47,7 +47,7 @@ def get_predict_cmd(
 
     predict_cmd = (
         f"singularity exec {singularity_exe} WisecondorX --loglevel info predict "
-        f"{str(out_prefix)}.bam.wcx.npz {reference} {str(out)} --plot --bed --blacklist "
+        f"{str(out_prefix)}.bam.wcx.npz {reference} {str(out)} --bed --blacklist "
         f"{blacklist} --zscore {zscore}"
     )
 

--- a/fluffy/samplesheet.py
+++ b/fluffy/samplesheet.py
@@ -34,12 +34,18 @@ def read_samplesheet(samplesheet: Iterator[str], project_dir: Path) -> Iterator[
     samples = set()
     sample_col = 0
 
+    first=True
     for line_nr, line in enumerate(samplesheet):
-        if line_nr == 0:
+
+        if line.startswith("[Data],,"):
+            continue
+
+        if first:
             separator = get_separator(line)
             LOG.debug("Use separator %s", separator)
             header = line.rstrip().split(separator)
             sample_col = get_sample_col(header)
+            first=False
             continue
 
         content = line.rstrip().split(separator)

--- a/fluffy/version.py
+++ b/fluffy/version.py
@@ -1,2 +1,2 @@
 """Holds current version of fluffy"""
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/scripts/generate_csv.py
+++ b/scripts/generate_csv.py
@@ -210,7 +210,7 @@ for line in open(args.samplesheet):
         line=line.replace("\t"," ")
         line=line.replace(";"," ")
 
-    if line.startswith("[Data],,"):
+    if line.startswith("[Data]"):
         continue
 
     if first:

--- a/scripts/generate_csv.py
+++ b/scripts/generate_csv.py
@@ -209,7 +209,10 @@ for line in open(args.samplesheet):
         line=line.replace(","," ")
         line=line.replace("\t"," ")
         line=line.replace(";"," ")
- 
+
+    if line.startswith("[Data],,"):
+        continue
+
     if first:
         i=0
         for entry in line.strip("\n").split(" "):

--- a/versioned_singularity/0.2.0
+++ b/versioned_singularity/0.2.0
@@ -1,0 +1,52 @@
+Bootstrap: docker
+From: ubuntu:16.04
+
+%environment
+SHELL=/bin/bash
+PATH=/opt/anaconda/bin:${PATH}
+LC_ALL=C.UTF-8
+
+%runscript
+    echo "This is what happens when you run the container..."
+    export PATH=/opt/anaconda/bin:${PATH}    
+
+%post
+    echo "Hello from inside the container"
+    apt-get update
+    apt-get -y install wget git bzip2 build-essential gcc zlib1g-dev language-pack-en-base apt-transport-https make cmake unzip python3 sudo python2.7 python-numpy python-matplotlib python-biopython samtools
+    update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+
+    cd /root/ && wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh
+    cd /root/ && chmod 700 ./Miniconda2-latest-Linux-x86_64.sh
+    cd /root/ && bash ./Miniconda2-latest-Linux-x86_64.sh -b -p /opt/anaconda/
+
+    export PATH=/opt/anaconda/bin:${PATH}
+
+    conda config --add channels defaults
+    conda config --add channels conda-forge
+    conda config --add channels bioconda
+    conda config --add channels r
+
+    conda install -f -c conda-forge -c bioconda wisecondorx
+    pip install -U git+https://github.com/CenterForMedicalGeneticsGhent/WisecondorX
+    conda install r-ichorcna
+    conda install -c bioconda samtools bwa sambamba minimap2 picard
+    conda install -c bioconda biobambam
+    
+    conda install -c conda-forge r-base
+    conda install -c r r-doparallel r-foreach r-neuralnet r-glmnet r-data.table r-mass
+
+    pip install sklearn numpy scipy matplotlib pysam futures bottleneck cython
+    cd /bin/ &&  git clone https://github.com/VUmcCGP/wisecondor.git    
+    
+    cd /bin/ && wget https://github.com/CenterForMedicalGeneticsGhent/PREFACE/archive/v0.1.1.zip && unzip v0.1.1.zip
+    cd /
+
+    cd /bin/ && git clone https://github.com/J35P312/AMYCNE.git && cd AMYCNE && python setup.py build_ext --inplace    
+    
+    git clone https://github.com/SciLifeLab/TIDDIT.git
+    mv TIDDIT/* /bin/
+    cd /bin/ && ./INSTALL.sh
+    chmod +x /bin/TIDDIT.py
+
+    cd /bin/ && git clone https://github.com/J35P312/FluFFyPipe.git


### PR DESCRIPTION
### This PR adds | fixes:
- fluffy can now use the bcl2fastq samplesheet as input (i.e files were the first line contains the string [data], and the second lien contains the header)
-imporved documentation and added an empty config template
-

**How to prepare for test**:
- [ ] `ssh` to hasta
- [ ] Install in home folder
-[] run according to manual

### How to test:
-run fluffy

### Expected outcome:
- [ ] fluffy should generate all deliverables files

### Review:
- [ ] Code approved by Jesper
- [ ] Tests executed by Jesper
- [ ] "Merge and deploy" approved by Jesper

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [X ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
