### PR TITLE
improved readme and internal reference mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ NIPT analysis pipeline, using WisecondorX for detecting aneuplodies and large CN
 </p>
 
 # Run FluFFyPipe
-Run NIPT analysis:
+Run NIPT analysis, using a previously comnputed reference:
 
     fluffy --sample <samplesheet>  --project <input_folder> --out <output_folder> analyse
+    
+Run NIPT analysis, using an internally computed reference (i.e the reference is built using all samples listed in samplesheet):
+
+    fluffy --sample <samplesheet>  --project <input_folder> --out <output_folder> analyse --batch-ref
 
 optionally, skip preface:
 
@@ -25,7 +29,7 @@ tiddit coverage summary
 Fetal fraction estimation
 ```
 
-as well as a summary csv (per batch)
+as well as a summary csv and multiqc html (per batch)
 
 the input folder is a project folder containing one folder per sample, each of these subfolders contain the fastq file(s).
 The samplesheet contains at least a "sampleID" column, the sampleID should match the subfolders in the input folder. The samplesheet may contain other columns, such as flowcell and index folder: such columns will be printed to the summary csv.
@@ -33,22 +37,53 @@ The samplesheet contains at least a "sampleID" column, the sampleID should match
 Create a WisecondorX reference
 
     fluffy --sample <samplesheet>  --project <input_folder> --out <output_folder> reference
-
+    
 samplesheet should contain atleast a "sampleID" column. All samples in the samplesheet will be used to construct the reference, visit the WisecondorX manual for more information.
 
+# Troubleshooting and rerun
+There are three statuses of the fluffy pipeline:
+running, complete, and failed
+
+The status of a fluffy run is found in the
+
+	<output_folder>/analysis_status.json
+	
+The status of all jobs are listed in
+
+	<output_folder>/sacct/fluffy_<date>.log.status
+	
+Where <date> is the timepoint when the jobs were submitted
+Use grep to find the failed jobs:
+	
+	grep -v COMPLETE <output_folder>/sacct/fluffy_<date>.log.status
+	
+The output logs are stored in:
+
+	 <output_folder>/logs
+
+Before continuing, you may want to generate the summary csv for all completed cases:
+
+	bash <output_folder>/scripts/summarizebatch-<hash>
+
+where <hash> is a randomly generated string.
+	
+use the rerun module to rerun failed fluffy analyses:
+
+	fluffy --sample <samplesheet>  --project <input_folder> --out <output_folder> --skip_preface rerun
+	
+ 
 # Install FluFFyPipe
 FluFFyPipe requires python 3, slurm, slurmpy, and singularity, python-coloredlogs.
 
-First clone fluffypipe:
+fluffy may be installed using pip:
 
-`git clone https://github.com/Clinical-Genomics/fluffy`
+	pip install fluffy-cg
 
-Install fluffy using pip
-
-cd fluffy
-
-`pip install -e .`
-
+alternatively, fluffy is cloned and installed from github:
+	git clone https://github.com/Clinical-Genomics/fluffy
+	cd fluffy
+	pip install -e .
+	
 Next download the FluFFyPipe singularity container
 
      singularity pull --name FluFFyPipe.sif shub://J35P312/FluFFyPipe
@@ -65,3 +100,6 @@ You will need to download/create the following files:
 	blacklist bed file (used by wisecondorX)
 
 	FluFFyPipe singularity collection (singularity pull --name FluFFyPipe.sif shub://J35P312/FluFFyPipe)
+	
+
+

--- a/fluffy/cli/make_analysis.py
+++ b/fluffy/cli/make_analysis.py
@@ -18,13 +18,14 @@ LOG = logging.getLogger(__name__)
 @click.option(
     "--skip-preface", is_flag=True, help="Skip preface fetal fraction estimation"
 )
+@click.option("--batch-ref", is_flag=True, help="Build a wisecondorX refeference from the input batch (overrides refpreface and reftest)")
 @click.option("--dry-run", is_flag=True, help="Do not create any files")
-def analyse(ctx, skip_preface, dry_run):
+def analyse(ctx, skip_preface, dry_run,batch_ref):
     """Run the pipeline to call NIPT"""
     LOG.info("Running fluffy analyse")
     samples = ctx.obj["samples"]
     configs = ctx.obj["configs"]
-    configs["sample_sheet"] = ctx.obj["sample_sheet"]
+    configs["sample_sheet"] = ctx.obj["sample_sheet"]	
     project_dir=ctx.obj["project"]
     slurm_api = ctx.obj["slurm_api"]
 
@@ -57,4 +58,5 @@ def analyse(ctx, skip_preface, dry_run):
         skip_preface=skip_preface,
         slurm_api=slurm_api,
         dry_run=dry_run,
+        batch_ref=batch_ref,
     )

--- a/fluffy/version.py
+++ b/fluffy/version.py
@@ -1,3 +1,3 @@
 """Holds current version of fluffy"""
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 


### PR DESCRIPTION
### This PR adds | fixes:
- use the --batch-ref to create an internal per batch reference. This is useful if you are running fluffy with large batches, or if you do not have any precomputed wisecondor reference
- I added a troubleshooting section to the README file

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
-

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
