### PR TITLE
Added multi threading for bwa Aln and samtools sort

### DIFF
--- a/fluffy/commands/bwa.py
+++ b/fluffy/commands/bwa.py
@@ -2,7 +2,15 @@
 
 
 def get_align_command(
-    singularity: str, sample_id: str,tmp_dir: str, reference: str, fastq: str,out_dir:str, out_prefix: str, read: str = None
+    fastq: str,
+    out_dir: str,
+    out_prefix: str,
+    reference: str,
+    singularity: str,
+    sample_id: str,
+    threads: str,
+    tmp_dir: str,
+    read: str = None,
 ) -> str:
     """create a command to run bwa align. Read can be r1, r2 or none"""
     read_prefix = ".sai"
@@ -11,9 +19,9 @@ def get_align_command(
     if read == "r2":
         read_prefix = "_R2.sai"
 
-    fastqc_prefix=read_prefix.replace(".sai","")
+    fastqc_prefix = read_prefix.replace(".sai", "")
     cmd = (
-        f"{singularity} bwa aln -n 0 -k 0 {reference} {fastq} > "
+        f"{singularity} bwa aln -n 0 -k 0 -t {threads} {reference} {fastq} > "
         f"{out_prefix}{read_prefix}\n"
         f"{singularity} cat {fastq} | {singularity} fastqc stdin:{sample_id}{fastqc_prefix} -d {tmp_dir} -o {out_dir}/{sample_id}"
     )
@@ -21,26 +29,31 @@ def get_align_command(
 
 
 def get_samse_command(
-    singularity: str, reference: str, fastq: str, out_prefix: str
+    fastq: str, out_prefix: str, reference: str, singularity: str, threads: str
 ) -> str:
     """create a command for running bwa samsw"""
-    cmd = f"{singularity} bwa samse -n -1 {reference} {out_prefix}.sai {fastq} | {singularity} samtools sort - -T {out_prefix}.tmp > {out_prefix}.tmp.bam"
+    cmd = f"{singularity} bwa samse -n -1 {reference} {out_prefix}.sai {fastq} | {singularity} samtools sort - -@ {threads} -T {out_prefix}.tmp > {out_prefix}.tmp.bam"
     return cmd
 
 
 def get_sampe_command(
-    singularity: str, reference: str, fastq1: str, fastq2: str, out_prefix: str
+    fastq1: str,
+    fastq2: str,
+    out_prefix: str,
+    reference: str,
+    singularity: str,
+    threads: str,
 ) -> str:
     """create a command for running bwa sampe"""
     cmd = (
         f"{singularity} bwa sampe -n -1 {reference} "
-        f"{out_prefix}_R1.sai {out_prefix}_R2.sai {fastq1} {fastq2} | {singularity} samtools sort - -T {out_prefix}.tmp > {out_prefix}.tmp.bam"
+        f"{out_prefix}_R1.sai {out_prefix}_R2.sai {fastq1} {fastq2} | {singularity} samtools sort - -@ {threads} -T {out_prefix}.tmp > {out_prefix}.tmp.bam"
     )
     return cmd
 
 
 def get_bamsormadup_command(
-    singularity: str, tmp_dir: str, sample_id: str, out_prefix: str
+    out_prefix: str, sample_id: str, singularity: str, tmp_dir: str
 ) -> str:
     """Create a command for running bamorsamdup"""
     cmd = (


### PR DESCRIPTION
### This PR adds:
- Multithreading for bwa Aln and samtools sort processes

**How to prepare for test**:
- [ ] `ssh` to hasta
- [ ] `activate stage`
- [ ] Install on stage:
`cg deploy fluffy`

### How to test:
- `cg workflow fluffy start <case_id>`

### Expected outcome:
- [ ] Analysis finishes without any issues

### Review:
- [ ] Code approved by
- [x] Tests executed by @karlnyr 
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
